### PR TITLE
fixed MongooseModel.find call with invalid objectId parameter 

### DIFF
--- a/src/bank-account/bank-account.service.ts
+++ b/src/bank-account/bank-account.service.ts
@@ -7,6 +7,7 @@ import { CreateBankAccountDto } from './dto/create-bank-account.dto';
 import { UpdateBankAccountDto } from './dto/update-bank-account.dto';
 import { BankAccount } from './entities/bank-account.entity';
 import * as mongoose from 'mongoose'
+import { InvalidInputException } from 'src/exceptions/global.exceptions';
 
 @Injectable()
 export class BankAccountService {
@@ -29,7 +30,15 @@ export class BankAccountService {
   }
 
   async findOne(id: string) : Promise<BankAccount> {
-    return await this.BankAccountModel.findById(id)
+
+    let foundAccount
+    try {
+      foundAccount = await this.BankAccountModel.findById(id)
+    } catch (error) {
+      if(error.message.includes('Cast to ObjectId failed')) throw new InvalidInputException('Invalid bank account id')
+    }
+
+    return foundAccount
   }
 
   async findByOwnerId(ownerId: string) : Promise<BankAccount[]> {

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -1,11 +1,10 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { BankAccountService } from 'src/bank-account/bank-account.service';
 import { BankAccount } from 'src/bank-account/entities/bank-account.entity';
 import { BankAccountNotFoundException } from 'src/exceptions/bank-account.exceptions';
+import { InvalidInputException } from 'src/exceptions/global.exceptions';
 import { LowBalanceException } from 'src/exceptions/transaction.exceptions';
-import { ConversionService } from '../conversion/conversion.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { Transaction } from './entities/transaction.entity';
 
@@ -45,7 +44,14 @@ export class TransactionService {
   }
 
   async findOne(id: string): Promise<Transaction> {
-    return await this.TransactionModel.findById(id)
+
+    let foundTransaction
+    try {
+      foundTransaction = await this.TransactionModel.findById(id)
+    } catch (error) {
+      if(error.message.includes('Cast to ObjectId failed')) throw new InvalidInputException('Invalid transaction id')
+    }
+    return foundTransaction
   }
 
 


### PR DESCRIPTION
### Description

This PR aims to fix a bug when calling `BankAccountModel.findById()` or `TransactionModel.findById()` with a parameter of type string but not a valid Mongoose.ObjectId which used to cause an unhandled `ServerIntenalError`